### PR TITLE
Add tables for NCT pairwise results

### DIFF
--- a/NCT_Test.R
+++ b/NCT_Test.R
@@ -1,24 +1,28 @@
-# 假设已有一个包含多个子数据集的列表 data_subsets
-n_sets <- length(data_subsets_3)
+# Assume a list of data subsets called data_subsets
+n_sets <- length(data_subsets)
 
-# 仅选择连续型变量（根据你的变量名自行调整）
+# Select numeric variables (adjust according to your variable names)
 vars_for_NCT <- vars[which(type_vec == "g")]
 
-# 对每个子数据集提取并标准化这些变量
+# Standardize these variables for each subset
 scaled_subsets <- lapply(data_subsets, function(dat) {
   scale(dat[, vars_for_NCT])
 })
 
-# 计算所有条件对（组合）
+# Create all condition pairs
 pairs_idx <- combn(n_sets, 2)
 
-# 存放所有 NCT 结果
+# Lists to store results
 nct_results <- list()
+global_strength_list <- list()
+network_structure_list <- list()
+edge_diff_list <- list()
 
 for (i in seq_len(ncol(pairs_idx))) {
   i1 <- pairs_idx[1, i]
   i2 <- pairs_idx[2, i]
-  
+  pair_name <- paste0(i1, "_vs_", i2)
+
   nct_res <- NCT(
     data1 = scaled_subsets[[i1]],
     data2 = scaled_subsets[[i2]],
@@ -28,10 +32,45 @@ for (i in seq_len(ncol(pairs_idx))) {
     test.centrality = FALSE,
     paired = FALSE
   )
-  
-  # 以“1_vs_2”格式命名结果列表
-  nct_results[[paste0(i1, "_vs_", i2)]] <- nct_res
+
+  nct_results[[pair_name]] <- nct_res
+
+  # Global strength difference table
+  global_strength_list[[pair_name]] <- data.frame(
+    condition_pair = pair_name,
+    network1_strength = nct_res$glstrinv.sep[1],
+    network2_strength = nct_res$glstrinv.sep[2],
+    strength_difference = nct_res$glstrinv.real,
+    p_value = nct_res$glstrinv.pval,
+    row.names = NULL
+  )
+
+  # Network structure difference table
+  network_structure_list[[pair_name]] <- data.frame(
+    condition_pair = pair_name,
+    structure_difference = nct_res$nwinv.real,
+    p_value = nct_res$nwinv.pval,
+    row.names = NULL
+  )
+
+  # Edge differences (only significant edges)
+  edge_df <- nct_res$einv.pvals
+  colnames(edge_df) <- c("Var1", "Var2", "p_value", "E")
+  edge_df <- subset(edge_df, p_value < 0.05)
+  edge_df <- edge_df[order(edge_df$p_value), ]
+  if (nrow(edge_df) > 0) {
+    edge_df$condition_pair <- pair_name
+    edge_df <- edge_df[, c("condition_pair", "Var1", "Var2", "E", "p_value")]
+  }
+  edge_diff_list[[pair_name]] <- edge_df
 }
 
-# 查看结果
-head(nct_results,50)
+# Combine lists into tables
+global_strength_table <- do.call(rbind, global_strength_list)
+network_structure_table <- do.call(rbind, network_structure_list)
+# edge_diff_list remains a list of tables for each pair
+
+# View results
+global_strength_table
+network_structure_table
+edge_diff_list


### PR DESCRIPTION
## Summary
- Add lists and tables to save NCT global strength, network structure, and edge differences for each pair of subsets
- Store only significant edge differences sorted by p-value for easier export

## Testing
- `Rscript NCT_Test.R` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while updating package lists)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6baa8c08321a1d104ac926cf30a