### PR TITLE
Add tables for NCT pairwise results

### DIFF
--- a/NCT_Test.R
+++ b/NCT_Test.R
@@ -1,37 +1,97 @@
-# 假设已有一个包含多个子数据集的列表 data_subsets
-n_sets <- length(data_subsets_3)
+library(NetworkComparisonTest)
 
-# 仅选择连续型变量（根据你的变量名自行调整）
-vars_for_NCT <- vars[which(type_vec == "g")]
+#' Run NCT across all pairs of data subsets
+#'
+#' @param data_subsets List of data frames for each condition
+#' @param vars_for_NCT Character vector of variable names to include in the networks
+#' @param gamma EBIC hyperparameter passed to `NCT`
+#' @param it Number of permutations for `NCT`
+#' @param alpha Significance level for edge differences
+#' @param test.centrality Logical; whether to test centrality differences
+#' @param paired Logical; whether data sets are paired
+#' @return A list containing tables for global strength, network structure,
+#'         and significant edge differences, along with full NCT results
+run_nct_pairs <- function(data_subsets,
+                          vars_for_NCT,
+                          gamma = 0.5,
+                          it = 100,
+                          alpha = 0.05,
+                          test.centrality = FALSE,
+                          paired = FALSE) {
+  n_sets <- length(data_subsets)
 
-# 对每个子数据集提取并标准化这些变量
-scaled_subsets <- lapply(data_subsets, function(dat) {
-  scale(dat[, vars_for_NCT])
-})
+  # Standardize selected variables for each subset
+  scaled_subsets <- lapply(data_subsets, function(dat) {
+    scale(dat[, vars_for_NCT])
+  })
 
-# 计算所有条件对（组合）
-pairs_idx <- combn(n_sets, 2)
+  # Generate all condition pairs
+  pairs_idx <- combn(n_sets, 2)
 
-# 存放所有 NCT 结果
-nct_results <- list()
+  # Storage lists
+  nct_results <- list()
+  global_strength_list <- list()
+  network_structure_list <- list()
+  edge_diff_list <- list()
 
-for (i in seq_len(ncol(pairs_idx))) {
-  i1 <- pairs_idx[1, i]
-  i2 <- pairs_idx[2, i]
-  
-  nct_res <- NCT(
-    data1 = scaled_subsets[[i1]],
-    data2 = scaled_subsets[[i2]],
-    gamma = 0.5,
-    it = 100,
-    test.edges = TRUE,
-    test.centrality = FALSE,
-    paired = FALSE
+  for (i in seq_len(ncol(pairs_idx))) {
+    i1 <- pairs_idx[1, i]
+    i2 <- pairs_idx[2, i]
+    pair_name <- paste0(i1, "_vs_", i2)
+
+    nct_res <- NCT(
+      data1 = scaled_subsets[[i1]],
+      data2 = scaled_subsets[[i2]],
+      gamma = gamma,
+      it = it,
+      test.edges = TRUE,
+      test.centrality = test.centrality,
+      paired = paired
+    )
+
+    nct_results[[pair_name]] <- nct_res
+
+    # Global strength difference
+    global_strength_list[[pair_name]] <- data.frame(
+      condition_pair = pair_name,
+      network1_strength = nct_res$glstrinv.sep[1],
+      network2_strength = nct_res$glstrinv.sep[2],
+      strength_difference = nct_res$glstrinv.real,
+      p_value = nct_res$glstrinv.pval,
+      row.names = NULL
+    )
+
+    # Network structure difference
+    network_structure_list[[pair_name]] <- data.frame(
+      condition_pair = pair_name,
+      structure_difference = nct_res$nwinv.real,
+      p_value = nct_res$nwinv.pval,
+      row.names = NULL
+    )
+
+    # Edge differences - keep significant edges only
+    edge_df <- nct_res$einv.pvals
+    colnames(edge_df) <- c("Var1", "Var2", "p_value", "E")
+    edge_df <- subset(edge_df, p_value < alpha)
+    edge_df <- edge_df[order(edge_df$p_value), ]
+    if (nrow(edge_df) > 0) {
+      edge_df$condition_pair <- pair_name
+      edge_df <- edge_df[, c("condition_pair", "Var1", "Var2", "E", "p_value")]
+    }
+    edge_diff_list[[pair_name]] <- edge_df
+  }
+
+  global_strength_table <- do.call(rbind, global_strength_list)
+  network_structure_table <- do.call(rbind, network_structure_list)
+
+  list(
+    global_strength = global_strength_table,
+    network_structure = network_structure_table,
+    edge_differences = edge_diff_list,
+    nct_results = nct_results
   )
-  
-  # 以“1_vs_2”格式命名结果列表
-  nct_results[[paste0(i1, "_vs_", i2)]] <- nct_res
 }
 
-# 查看结果
-head(nct_results,50)
+# Example usage:
+# vars_for_NCT <- c("var1", "var2", "var3")
+# results <- run_nct_pairs(data_subsets, vars_for_NCT)


### PR DESCRIPTION
## Summary
- Add lists and tables to save NCT global strength, network structure, and edge differences for each pair of subsets
- Wrap pairwise NCT logic into reusable `run_nct_pairs` function accepting data subsets and parameters

## Testing
- `Rscript NCT_Test.R` *(fails: command not found: Rscript)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.163 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68acb6baa8c08321a1d104ac926cf30a